### PR TITLE
Reorder the elements for the series and dataset pages / Minor changes

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/table.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/table.html
@@ -1,0 +1,79 @@
+<table class="gn-resultview table table-bordered table-hover gn-card-table">
+  <thead>
+  <tr>
+    <th></th>
+    <th data-translate="">title</th>
+    <th data-translate="">cl_status</th>
+    <th data-translate="">actions</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr data-ng-repeat="md in searchResults.records"
+      gn-displayextent-onhover=""
+      gn-zoomto-onclick=""
+      data-ng-class="{'gn-record-selected': md.selected}"
+      gn-fix-mdlinks="">
+
+    <td class="gn-md-select">
+      <input gn-selection-md type="checkbox"
+             ng-model="md.selected"
+             aria-label="{{'clickToSelect' | translate}}"
+             ng-change="change()"/>
+    </td>
+
+    <td class="gn-md-title">
+      <h1>
+        <a href=""
+           gn-metadata-open="md"
+           gn-index="$index"
+           gn-records="searchResults.records"
+           gn-formatter="formatter.defaultUrl"
+           title="{{md.title || md.defaultTitle}}"
+           aria-label="{{md.resourceTitle}}">
+
+          {{md.resourceTitle}}</a>
+      </h1>
+    </td>
+    <td>
+      <div data-ng-if="md.cl_status.length > 0"
+           title="{{md.cl_status[0].key | translate}}"
+           class="gn-status gn-status-{{md.cl_status[0].key}}">{{md.cl_status[0].key | translate}}
+      </div>
+    </td>
+    <td>
+      <div class="gn-toolbar clearfix">
+        <div class="gn-md-category pull-left"
+             title="{{'listOfCategories' | translate}}"
+             data-ng-class="md.category.length > 0 ||
+                          md.topic.length > 0 ||
+                          md.inspireThemeUri.length > 0 ? '' : 'invisible'">
+          <i class="fa"
+             data-ng-repeat="cat in ::md.category"
+             title="{{('cat-' + cat) | translate}}"
+             aria-label="{{('cat-' + cat) | translate}}">
+            <span class="fa gn-icon-{{cat}}"></span>
+          </i>
+          <i  data-ng-repeat="t in md.inspireThemeUri track by $index"
+              data-ng-init="code = t.slice(t.lastIndexOf('/') + 1)"
+              class="fa" title="{{::(md.inspireTheme_syn && md.inspireTheme_syn[$index]) || code}}">
+            <span class="fa iti-{{::code}}"></span>
+          </i>
+          <i data-ng-repeat="t in md.topic"
+             title="{{t | translate}}"
+             aria-label="{{t | translate}}"
+             class="fa gn-icon-{{t}}">
+          </i>
+        </div>
+
+        <gn-links-btn class="pull-left"></gn-links-btn>
+        <div data-ng-if="(md.draft == 'e') && (md.edit == true)"
+             title="{{'workingCopy' | translate}}"
+             class="gn-workingcopy-status pull-left">
+          <i class="fa fa-pencil"></i>
+          <span>{{'workingCopy' | translate}}</span>
+        </div>
+      </div>
+    </td>
+  </tr>
+  </tbody>
+</table>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -564,6 +564,11 @@ goog.require('gn_alert');
               'search/resultsview/partials/viewtemplates/list.html',
             'tooltip': 'List',
             'icon': 'fa-bars'
+          },{
+            'tplUrl': '../../catalog/components/' +
+              'search/resultsview/partials/viewtemplates/table.html',
+            'tooltip': 'Table',
+            'icon': 'fa-table'
           }],
           'resultTemplate': '../../catalog/components/' +
               'search/resultsview/partials/viewtemplates/grid.html',

--- a/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
@@ -247,13 +247,13 @@
         regexpFlags: ''
       };
       $scope.searchAndReplaceChanges = [];
-      $scope.searchAndReplaceChanges.push($scope.searchAndReplaceField);
+      $scope.searchAndReplaceChanges[0] = $scope.searchAndReplaceField;
       $scope.regexpFlags = ['i', 'c', 'n', 'm'];
 
       $scope.setType = function(type) {
         $scope.editType = type;
         if (type === 'searchAndReplace') {
-          $scope.searchAndReplaceChanges.push($scope.searchAndReplaceField);
+          $scope.searchAndReplaceChanges[0] = $scope.searchAndReplaceField;
         } else {
           $scope.searchAndReplaceChanges.length = 0;
         }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1434,13 +1434,13 @@ gn-indexing-task-status {
 .height-auto { height: auto !important; max-height: none !important; }
 .col-2 {
   column-count: 2;
-  div {
+  &>div {
     break-inside: avoid;
   }
 }
 .col-3 {
   column-count: 3;
-  div {
+  &>div {
     break-inside: avoid;
   }
 }

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -6,6 +6,10 @@
     </div>
   </div>
 
+  <div class="alert alert-warning" data-ng-show="groups.length === 0"
+       data-translate="">youAreNotMemberOfAnyGroup
+  </div>
+
   <div class="row progress-bar-c1ontainer">
     <div class="col-sm-12 progress-bar-container-fixed gn-width-inherit1">
       <div id="gn-import-progress-row"
@@ -17,7 +21,7 @@
   </div>
 
   <!-- TODO : add form constraints -->
-  <div class="row">
+  <div class="row" data-ng-show="groups.length > 0">
     <div class="col-sm-8">
       <div class="panel panel-default">
         <div class="panel-body">

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  <div class="row" data-ng-show="hasTemplates">
+  <div class="row" data-ng-show="hasTemplates && groups.length > 0">
     <div class="col-sm-2">
       <div class="panel panel-default dynamic-list">
         <div class="panel-heading">

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <div class="row" data-ng-show="hasTemplates">
+  <div class="row" data-ng-show="hasTemplates && groups.length > 0">
     <div class="col-sm-4">
       <span data-translate="">createA</span>
           <strong>{{(activeType || '...') | translate}}</strong>
@@ -39,7 +39,7 @@
       </div>
     </div>
   </div>
-  <div class="row">
+  <div class="row" data-ng-show="hasTemplates && groups.length > 0">
     <div class="col-sm-4">
       <span data-translate="">fromTemplate</span>
       <strong>{{(activeTpl.title || '...') | translate}}</strong>
@@ -76,7 +76,7 @@
          data-exclude-special-groups="true"/>
     </div>
   </div>
-  <div class="row" data-ng-show="hasTemplates && !generateUuid">
+  <div class="row"  data-ng-show="hasTemplates && groups.length > 0 && !generateUuid">
     <div class="col-sm-4">
       <span data-translate="">createMetadataUniformResourceName</span>
     </div>
@@ -106,7 +106,7 @@
       </div>
     </div>
   </div>
-  <div class="row">
+  <div class="row" data-ng-show="hasTemplates && groups.length > 0">
     <div class="col-sm-8 col-sm-offset-4">
       <div class="dropup gn-margin-top">
         <div class="btn-group">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
@@ -314,6 +314,33 @@ ul.gn-resultview {
     }
   }
 }
+table.gn-resultview {
+  td {
+    vertical-align: middle !important;
+  }
+  h1 {
+    display: inline-block;
+    font-size: 14px;
+    padding: 0;
+    margin: 0;
+  }
+  .gn-md-links {
+    display: flex;
+    gap: 3px;
+  }
+  .gn-status {
+    position: inherit;
+    border-width: 1px;
+    white-space: nowrap;
+    margin-top: 0;
+    font-size: 100%;
+    margin: auto;
+    border-radius: 3px;
+  }
+  .gn-record-selected {
+    background-color: #f5f5f5;
+  }
+}
 
 // all info lists (home, map, portal)
 .gn-info-list {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -1,95 +1,100 @@
-<section class="gn-md-side-dates"
+<div>
+  <section class="gn-md-side-dates"
          data-ng-if="mdView.current.record.resourceDate.length > 0">
-  <ul>
-    <li data-ng-repeat="date in mdView.current.record.resourceDate">
-      <div class="badge badge-rounded"
-           data-ng-class="{'danger': date.type === 'deprecated'}">
-        <i class="fa fa-fw"
-           data-ng-class="{'fa-chevron-right': date.type === 'creation', 'fa-code-fork': date.type === 'superseded','fa-ban': date.type === 'deprecated', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}" />
-      </div>
-      <span>
-        <h3 data-translate>{{date.type | translate}}</h3>
-        <span data-gn-humanize-time="{{date.date}}"></span>
-      </span>
-    </li>
-  </ul>
-</section>
-
-<div data-ng-if="mdView.current.record.cl_maintenanceAndUpdateFrequency.length > 0"
-     class="gn-margin-bottom flex-row">
-  <span class="badge badge-rounded" title="{{'updateFrequency' | translate}}">
-    <i class="fa fa-fw fa-language"></i>
-  </span>
-  <div>
-    <h3 data-translate="">updateFrequency</h3>
-    <p data-ng-repeat="c in mdView.current.record.cl_maintenanceAndUpdateFrequency">
-      {{c.default}}
-    </p>
-  </div>
-</div>
-
-<div data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
-     data-ng-if="(user.canEditRecord(mdView.current.record)
-               && viewConfig.internalThesaurus
-               && viewConfig.internalThesaurus.indexOf(key) !== -1)
-              || highlightedThesaurus.indexOf(key) === -1"
-     class="gn-margin-bottom flex-row">
-  <span class="badge badge-rounded">
-    <i class="fa fa-fw fa-tags"></i>
-  </span>
-  <div>
-    <h3 data-translate="">{{(t.title || key) | translate}}</h3>
-
-    <div data-gn-keyword-badges="mdView.current.record"
-         data-thesaurus="key" />
-  </div>
-</div>
-
-<!-- Resource identifier-->
-<div data-ng-if="mdView.current.record.resourceIdentifier"
-     class="gn-margin-bottom flex-row">
-  <span class="badge badge-rounded" title="{{identifier | translate}}">
-    <i class="fa fa-fw fa-info"></i>
-  </span>
-  <div>
-    <h3 data-translate="">identifier</h3>
-    <ul class="gn-comma-list">
-      <li data-ng-repeat="i in mdView.current.record.resourceIdentifier">
-        <span data-ng-bind-html="i.code | linky" />
-      </li>
-    </ul>
-  </div>
-</div>
-
-<!-- Language-->
-<div data-ng-if="mdView.current.record.resourceLanguage.length > 0"
-     class="gn-margin-bottom flex-row">
-  <span class="badge badge-rounded" title="{{'language' | translate}}">
-    <i class="fa fa-fw fa-language"></i>
-  </span>
-  <div>
-    <h3 data-translate="">language</h3>
-    <ul class="gn-comma-list">
-      <li data-ng-repeat="l in mdView.current.record.resourceLanguage">
-        {{l | translate}}
-      </li>
-    </ul>
-  </div>
-</div>
-
-<div ng-include="'../../catalog/views/default/templates/recordView/categories.html'" />
-
-<div data-ng-if="mdView.current.record.cl_classification > 0"
-     class="gn-margin-bottom flex-row">
-  <span class="badge badge-rounded" title="{{'classification' | translate}}">
-    <i class="fa fa-fw fa-tags"></i>
-  </span>
-  <div>
-    <h3 data-translate="">classification</h3>
     <ul>
-      <li data-ng-repeat="c in mdView.current.record.cl_classification">{{c.default}}</li>
+      <li data-ng-repeat="date in mdView.current.record.resourceDate">
+        <div class="badge badge-rounded"
+             data-ng-class="{'danger': date.type === 'deprecated'}">
+          <i class="fa fa-fw"
+             data-ng-class="{'fa-chevron-right': date.type === 'creation', 'fa-code-fork': date.type === 'superseded','fa-ban': date.type === 'deprecated', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}" />
+        </div>
+        <span>
+          <h3 data-translate>{{date.type | translate}}</h3>
+          <span data-gn-humanize-time="{{date.date}}"></span>
+        </span>
+      </li>
     </ul>
-  </div>
+  </section>
 
+  <div data-ng-if="mdView.current.record.cl_maintenanceAndUpdateFrequency.length > 0"
+       class="gn-margin-bottom flex-row">
+    <span class="badge badge-rounded" title="{{'updateFrequency' | translate}}">
+      <i class="fa fa-fw fa-language"></i>
+    </span>
+    <div>
+      <h3 data-translate="">updateFrequency</h3>
+      <p data-ng-repeat="c in mdView.current.record.cl_maintenanceAndUpdateFrequency">
+        {{c.default}}
+      </p>
+    </div>
+  </div>
 </div>
 
+<div>
+  <div data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
+       data-ng-if="(user.canEditRecord(mdView.current.record)
+                 && viewConfig.internalThesaurus
+                 && viewConfig.internalThesaurus.indexOf(key) !== -1)
+                || highlightedThesaurus.indexOf(key) === -1"
+       class="gn-margin-bottom flex-row">
+    <span class="badge badge-rounded">
+      <i class="fa fa-fw fa-tags"></i>
+    </span>
+    <div>
+      <h3 data-translate="">{{(t.title || key) | translate}}</h3>
+
+      <div data-gn-keyword-badges="mdView.current.record"
+           data-thesaurus="key" />
+    </div>
+  </div>
+</div>
+
+<div>
+  <!-- Resource identifier-->
+  <div data-ng-if="mdView.current.record.resourceIdentifier"
+       class="gn-margin-bottom flex-row">
+    <span class="badge badge-rounded" title="{{identifier | translate}}">
+      <i class="fa fa-fw fa-info"></i>
+    </span>
+    <div>
+      <h3 data-translate="">identifier</h3>
+      <ul class="gn-comma-list">
+        <li data-ng-repeat="i in mdView.current.record.resourceIdentifier">
+          <span data-ng-bind-html="i.code | linky" />
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Language-->
+  <div data-ng-if="mdView.current.record.resourceLanguage.length > 0"
+       class="gn-margin-bottom flex-row">
+    <span class="badge badge-rounded" title="{{'language' | translate}}">
+      <i class="fa fa-fw fa-language"></i>
+    </span>
+    <div>
+      <h3 data-translate="">language</h3>
+      <ul class="gn-comma-list">
+        <li data-ng-repeat="l in mdView.current.record.resourceLanguage">
+          {{l | translate}}
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div ng-include="'../../catalog/views/default/templates/recordView/categories.html'" />
+
+  <div data-ng-if="mdView.current.record.cl_classification > 0"
+       class="gn-margin-bottom flex-row">
+    <span class="badge badge-rounded" title="{{'classification' | translate}}">
+      <i class="fa fa-fw fa-tags"></i>
+    </span>
+    <div>
+      <h3 data-translate="">classification</h3>
+      <ul>
+        <li data-ng-repeat="c in mdView.current.record.cl_classification">{{c.default}}</li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -84,7 +84,7 @@
 </div>
 
 <div class="row gn-section"
-     data-ng-if="mdView.current.record.featureTypes
+     data-ng-if="mdView.current.record.featureTypes.length
                  || mdView.current.record.relatedRecords.fcats.length > 0">
   <div class="col-md-12 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/featurecatalogue.html'"/>
@@ -104,14 +104,13 @@
   </div>
 </div>
 
-<div class="row"
+<div class="row gn-section"
      data-ng-if="mdView.current.record.specificationConformance">
   <div class="col-md-8 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/quality.html'"/>
   </div>
 </div>
 
-<!-- contact -->
 <div class="row gn-section">
   <div class="col-md-8 gn-record gn-break">
     <div ng-include="'../../catalog/views/default/templates/recordView/contact.html'"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -65,7 +65,7 @@
 </div>
 
 <div class="row gn-section"
-     data-ng-if="mdView.current.record.featureTypes
+     data-ng-if="mdView.current.record.featureTypes.length
                  || mdView.current.record.relatedRecords.fcats.length > 0">
   <div class="col-md-12 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/featurecatalogue.html'"/>
@@ -80,7 +80,7 @@
 </div>
 
 <!-- lineage -->
-<div class="gn-section"
+<div class="row gn-section"
      data-ng-if="mdView.current.record.lineage
                  || mdView.current.record.sourceDescription
                  || mdView.current.record.supplementalInformation">


### PR DESCRIPTION
Some minor improvement on top of https://github.com/geonetwork/core-geonetwork/pull/6252 (and aligned with main)

* Technical info - 3 columns preserving groups of info
* Avoid some empty sections - bottom grey line

![image](https://user-images.githubusercontent.com/1701393/164188721-be088aca-71c3-4a7e-b027-e54503f04363.png)
