### PR TITLE
Fix button position in the load metadata and templates page

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-and-template.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-and-template.html
@@ -72,11 +72,11 @@
               <span data-translate="">loadSamplesForSelectedSchema</span>
             </button>
           </div>
-
-          <div data-gn-need-help="standards-home"></div>
         </div>
       </div>
     </div>
+
+    <div data-gn-need-help="standards-home"></div>
   </div>
   <div class="col-lg-4">
     <div


### PR DESCRIPTION
Fixes the button position in the `Load metadata and templates` page.

**Previously:**

![old](https://user-images.githubusercontent.com/1695003/192526416-90c6a678-7d91-4681-8421-75540685d509.png)


**With the change:**

![updated](https://user-images.githubusercontent.com/1695003/192526444-d27ff400-796e-4945-8480-23f75cab0a17.png)
